### PR TITLE
[FLINK-25583] Support compacting small files for FileSink.

### DIFF
--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -112,6 +112,11 @@ under the License.
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>test</scope>
+        </dependency>
 
 		<!-- ArchUit test dependencies -->
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
@@ -28,6 +28,8 @@ import org.apache.flink.api.connector.sink2.StatefulSink;
 import org.apache.flink.api.connector.sink2.StatefulSink.WithCompatibleState;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
 import org.apache.flink.connector.file.sink.committer.FileCommitter;
+import org.apache.flink.connector.file.sink.compactor.FileCompactStrategy;
+import org.apache.flink.connector.file.sink.compactor.FileCompactor;
 import org.apache.flink.connector.file.sink.writer.DefaultFileWriterBucketFactory;
 import org.apache.flink.connector.file.sink.writer.FileWriter;
 import org.apache.flink.connector.file.sink.writer.FileWriterBucketFactory;
@@ -177,6 +179,14 @@ public class FileSink<IN>
                 basePath, bulkWriterFactory, new DateTimeBucketAssigner<>());
     }
 
+    public BucketWriter<IN, String> createBucketWriter() throws IOException {
+        return bucketsBuilder.createBucketWriter();
+    }
+
+    public FileCompactor getFileCompactor() {
+        return bucketsBuilder.getFileCompactor();
+    }
+
     /** The base abstract class for the {@link RowFormatBuilder} and {@link BulkFormatBuilder}. */
     @Internal
     private abstract static class BucketsBuilder<IN, T extends BucketsBuilder<IN, T>>
@@ -204,6 +214,15 @@ public class FileSink<IN>
         @Internal
         abstract SimpleVersionedSerializer<FileSinkCommittable> getCommittableSerializer()
                 throws IOException;
+
+        @Internal
+        abstract FileCompactStrategy getCompactStrategy();
+
+        @Internal
+        abstract FileCompactor getFileCompactor();
+
+        @Internal
+        abstract BucketWriter<IN, String> createBucketWriter() throws IOException;
     }
 
     /** A builder for configuring the sink for row-wise encoding formats. */
@@ -225,6 +244,10 @@ public class FileSink<IN>
         private RollingPolicy<IN, String> rollingPolicy;
 
         private OutputFileConfig outputFileConfig;
+
+        private FileCompactStrategy compactStrategy;
+
+        private FileCompactor fileCompactor;
 
         protected RowFormatBuilder(
                 Path basePath, Encoder<IN> encoder, BucketAssigner<IN, String> bucketAssigner) {
@@ -300,6 +323,16 @@ public class FileSink<IN>
         }
 
         @Override
+        FileCompactStrategy getCompactStrategy() {
+            return compactStrategy;
+        }
+
+        @Override
+        FileCompactor getFileCompactor() {
+            return fileCompactor;
+        }
+
+        @Override
         SimpleVersionedSerializer<FileWriterBucketState> getWriterStateSerializer()
                 throws IOException {
             BucketWriter<IN, String> bucketWriter = createBucketWriter();
@@ -319,7 +352,7 @@ public class FileSink<IN>
                     bucketWriter.getProperties().getInProgressFileRecoverableSerializer());
         }
 
-        private BucketWriter<IN, String> createBucketWriter() throws IOException {
+        BucketWriter<IN, String> createBucketWriter() throws IOException {
             return new RowWiseBucketWriter<>(
                     FileSystem.get(basePath.toUri()).createRecoverableWriter(), encoder);
         }
@@ -356,6 +389,10 @@ public class FileSink<IN>
         private CheckpointRollingPolicy<IN, String> rollingPolicy;
 
         private OutputFileConfig outputFileConfig;
+
+        private FileCompactStrategy compactStrategy;
+
+        private FileCompactor fileCompactor;
 
         protected BulkFormatBuilder(
                 Path basePath,
@@ -449,6 +486,16 @@ public class FileSink<IN>
         }
 
         @Override
+        FileCompactStrategy getCompactStrategy() {
+            return compactStrategy;
+        }
+
+        @Override
+        FileCompactor getFileCompactor() {
+            return fileCompactor;
+        }
+
+        @Override
         SimpleVersionedSerializer<FileWriterBucketState> getWriterStateSerializer()
                 throws IOException {
             BucketWriter<IN, String> bucketWriter = createBucketWriter();
@@ -468,7 +515,7 @@ public class FileSink<IN>
                     bucketWriter.getProperties().getInProgressFileRecoverableSerializer());
         }
 
-        private BucketWriter<IN, String> createBucketWriter() throws IOException {
+        BucketWriter<IN, String> createBucketWriter() throws IOException {
             return new BulkBucketWriter<>(
                     FileSystem.get(basePath.toUri()).createRecoverableWriter(), writerFactory);
         }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSink.java
@@ -339,6 +339,18 @@ public class FileSink<IN>
             return self();
         }
 
+        public T enableCompact(final FileCompactStrategy strategy, final FileCompactor compactor) {
+            this.compactStrategy = strategy;
+            // we always commit before compacting, so hide the file written by writer
+            this.outputFileConfig =
+                    OutputFileConfig.builder()
+                            .withPartPrefix("." + outputFileConfig.getPartPrefix())
+                            .withPartSuffix(outputFileConfig.getPartSuffix())
+                            .build();
+            this.fileCompactor = compactor;
+            return self();
+        }
+
         /** Creates the actual sink. */
         public FileSink<IN> build() {
             return new FileSink<>(this);
@@ -500,6 +512,18 @@ public class FileSink<IN>
                     rollingPolicy,
                     bucketFactory,
                     outputFileConfig);
+        }
+
+        public T enableCompact(final FileCompactStrategy strategy, final FileCompactor compactor) {
+            this.compactStrategy = strategy;
+            // we always commit before compacting, so hide the file written by writer
+            this.outputFileConfig =
+                    OutputFileConfig.builder()
+                            .withPartPrefix("." + outputFileConfig.getPartPrefix())
+                            .withPartSuffix(outputFileConfig.getPartSuffix())
+                            .build();
+            this.fileCompactor = compactor;
+            return self();
         }
 
         /** Creates the actual sink. */

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSinkCommittable.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/FileSinkCommittable.java
@@ -19,11 +19,13 @@
 package org.apache.flink.connector.file.sink;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter;
 
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -34,26 +36,51 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Internal
 public class FileSinkCommittable implements Serializable {
 
+    private final String bucketId;
+
     @Nullable private final InProgressFileWriter.PendingFileRecoverable pendingFile;
 
     @Nullable private final InProgressFileWriter.InProgressFileRecoverable inProgressFileToCleanup;
 
-    public FileSinkCommittable(InProgressFileWriter.PendingFileRecoverable pendingFile) {
+    @Nullable private final Path compactedFileToCleanup;
+
+    public FileSinkCommittable(
+            String bucketId, InProgressFileWriter.PendingFileRecoverable pendingFile) {
+        this.bucketId = bucketId;
         this.pendingFile = checkNotNull(pendingFile);
         this.inProgressFileToCleanup = null;
+        this.compactedFileToCleanup = null;
     }
 
     public FileSinkCommittable(
+            String bucketId,
             InProgressFileWriter.InProgressFileRecoverable inProgressFileToCleanup) {
+        this.bucketId = bucketId;
         this.pendingFile = null;
         this.inProgressFileToCleanup = checkNotNull(inProgressFileToCleanup);
+        this.compactedFileToCleanup = null;
+    }
+
+    public FileSinkCommittable(String bucketId, Path compactedFileToCleanup) {
+        this.bucketId = bucketId;
+        this.pendingFile = null;
+        this.inProgressFileToCleanup = null;
+        this.compactedFileToCleanup = checkNotNull(compactedFileToCleanup);
     }
 
     FileSinkCommittable(
+            String bucketId,
             @Nullable InProgressFileWriter.PendingFileRecoverable pendingFile,
-            @Nullable InProgressFileWriter.InProgressFileRecoverable inProgressFileToCleanup) {
+            @Nullable InProgressFileWriter.InProgressFileRecoverable inProgressFileToCleanup,
+            @Nullable Path compactedFileToCleanup) {
+        this.bucketId = bucketId;
         this.pendingFile = pendingFile;
         this.inProgressFileToCleanup = inProgressFileToCleanup;
+        this.compactedFileToCleanup = compactedFileToCleanup;
+    }
+
+    public String getBucketId() {
+        return bucketId;
     }
 
     public boolean hasPendingFile() {
@@ -72,5 +99,34 @@ public class FileSinkCommittable implements Serializable {
     @Nullable
     public InProgressFileWriter.InProgressFileRecoverable getInProgressFileToCleanup() {
         return inProgressFileToCleanup;
+    }
+
+    public boolean hasCompactedFileToCleanup() {
+        return compactedFileToCleanup != null;
+    }
+
+    @Nullable
+    public Path getCompactedFileToCleanup() {
+        return compactedFileToCleanup;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FileSinkCommittable that = (FileSinkCommittable) o;
+        return Objects.equals(bucketId, that.bucketId)
+                && Objects.equals(pendingFile, that.pendingFile)
+                && Objects.equals(inProgressFileToCleanup, that.inProgressFileToCleanup)
+                && Objects.equals(compactedFileToCleanup, that.compactedFileToCleanup);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(bucketId, pendingFile, inProgressFileToCleanup, compactedFileToCleanup);
     }
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/ConcatFileCompactor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/ConcatFileCompactor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+/**
+ * A {@link OutputStreamBasedFileCompactor} implementation that simply concat the compacting files.
+ * The fileDelimiter will be added between neighbouring files if provided.
+ */
+public class ConcatFileCompactor extends OutputStreamBasedFileCompactor {
+
+    private static final int CHUNK_SIZE = 4 * 1024 * 1024;
+
+    private final byte[] fileDelimiter;
+
+    public ConcatFileCompactor() {
+        this(null);
+    }
+
+    public ConcatFileCompactor(@Nullable byte[] fileDelimiter) {
+        this.fileDelimiter = fileDelimiter;
+    }
+
+    @Override
+    protected void doCompact(List<Path> inputFiles, OutputStream outputStream) throws Exception {
+        FileSystem fs = inputFiles.get(0).getFileSystem();
+        for (Path input : inputFiles) {
+            try (FSDataInputStream inputStream = fs.open(input)) {
+                copy(inputStream, outputStream);
+            }
+            if (fileDelimiter != null) {
+                outputStream.write(fileDelimiter);
+            }
+        }
+    }
+
+    private void copy(InputStream in, OutputStream out) throws IOException {
+        byte[] buf = new byte[CHUNK_SIZE];
+        int length;
+        while ((length = in.read(buf)) > 0) {
+            out.write(buf, 0, length);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/DecoderBasedReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/DecoderBasedReader.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.Path;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+
+/**
+ * A {@link RecordWiseFileCompactor.Reader} implementation that reads the file as an {@link
+ * FSDataInputStream} and decodes the record with the {@link Decoder}.
+ */
+public class DecoderBasedReader<T> implements RecordWiseFileCompactor.Reader<T> {
+    private final Decoder<T> decoder;
+    private final FSDataInputStream input;
+
+    public DecoderBasedReader(Path path, Decoder<T> decoder) throws IOException {
+        this.decoder = decoder;
+        this.input = path.getFileSystem().open(path);
+    }
+
+    @Override
+    public T read() throws IOException {
+        if (input.available() > 0) {
+            return decoder.decodeNext(input);
+        }
+        return null;
+    }
+
+    @Override
+    public void close() throws Exception {
+        input.close();
+    }
+
+    /**
+     * A {@link Decoder} to decode the file content into the actual records.
+     *
+     * <p>A {@link Decoder} is generally the reverse of a {@link
+     * org.apache.flink.api.common.serialization.Encoder}.
+     *
+     * @param <T> Thy type of the records the reader is reading.
+     */
+    public interface Decoder<T> extends Serializable {
+        /**
+         * @return The next record that decoded from the InputStream, or null if no more available.
+         */
+        T decodeNext(InputStream input) throws IOException;
+    }
+
+    /** Factory for {@link DecoderBasedReader}. */
+    public static class Factory<T> implements RecordWiseFileCompactor.Reader.Factory<T> {
+        private final Decoder<T> decoder;
+
+        public Factory(Decoder<T> decoder) {
+            this.decoder = decoder;
+        }
+
+        @Override
+        public DecoderBasedReader<T> open(Path path) throws IOException {
+            return new DecoderBasedReader<>(path, decoder);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/FileCompactStrategy.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/FileCompactStrategy.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.connector.file.sink.FileSink;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** Strategy for compacting the files written in {@link FileSink} before committing. */
+public class FileCompactStrategy implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    // Compaction triggering strategies.
+    private final long sizeThreshold;
+    private final long maxIntervalMs;
+    private final boolean crossCheckpoints;
+
+    // Compaction executing strategies.
+    private final int compactThread;
+
+    private FileCompactStrategy(
+            long sizeThreshold, long maxIntervalMs, boolean crossCheckpoints, int compactThread) {
+        this.sizeThreshold = sizeThreshold;
+        this.maxIntervalMs = maxIntervalMs;
+        this.crossCheckpoints = crossCheckpoints;
+        this.compactThread = compactThread;
+    }
+
+    public long getSizeThreshold() {
+        return sizeThreshold;
+    }
+
+    public long getMaxIntervalMs() {
+        return maxIntervalMs;
+    }
+
+    public boolean isCrossCheckpoints() {
+        return crossCheckpoints;
+    }
+
+    public int getCompactThread() {
+        return compactThread;
+    }
+
+    /** Builder for {@link FileCompactStrategy}. */
+    public static class Builder {
+        private long sizeThreshold = -1;
+        private long maxIntervalMs = -1;
+        private boolean crossCheckpoints = true;
+        private int compactThread = 1;
+
+        public static FileCompactStrategy.Builder newBuilder() {
+            return new FileCompactStrategy.Builder();
+        }
+
+        /**
+         * Optional, compaction will be triggered when the total size of compacting files reaches
+         * the threshold. -1 by default, indicating the size is unlimited.
+         */
+        public FileCompactStrategy.Builder withSizeThreshold(long sizeThreshold) {
+            this.sizeThreshold = sizeThreshold;
+            return this;
+        }
+
+        /**
+         * Optional, max interval since the last compaction triggering. -1 by default, indicating
+         * the interval is unlimited. The triggering will actually happen at the next checkpoint.
+         */
+        public FileCompactStrategy.Builder withMaxIntervalMs(long maxIntervalMs) {
+            this.maxIntervalMs = maxIntervalMs;
+            return this;
+        }
+
+        /** Optional, whether to compact files of different checkpoints, true by default. */
+        public FileCompactStrategy.Builder setCrossCheckpoints(boolean crossCheckpoints) {
+            this.crossCheckpoints = crossCheckpoints;
+            return this;
+        }
+
+        /** Optional, the count of compacting threads in a compactor operator, 1 by default. */
+        public FileCompactStrategy.Builder withCompactThread(int compactThread) {
+            checkArgument(compactThread > 0, "Compact thread should be more than 0.");
+            this.compactThread = compactThread;
+            return this;
+        }
+
+        public FileCompactStrategy build() {
+            validate();
+            return new FileCompactStrategy(
+                    sizeThreshold, maxIntervalMs, crossCheckpoints, compactThread);
+        }
+
+        private void validate() {
+            if (sizeThreshold < 0 && maxIntervalMs < 0) {
+                throw new IllegalArgumentException(
+                        "At least one of the sizeThreshold and the maxIntervalMs should be configured.");
+            }
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/FileCompactor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/FileCompactor.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.functions.sink.filesystem.CompactingFileWriter;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * The {@link FileCompactor} is responsible for compacting files into one file.
+ *
+ * <p>The {@link FileCompactor} should declare which type of {@link CompactingFileWriter} is
+ * required, and invoke the writer correspondingly.
+ */
+public interface FileCompactor extends Serializable {
+
+    /** @return the {@link CompactingFileWriter} type the compactor will use. */
+    CompactingFileWriter.Type getWriterType();
+
+    /**
+     * Compact the given files into one file.
+     *
+     * @param inputFiles the files to be compacted.
+     * @param writer the writer to write the compacted file.
+     * @throws Exception Thrown if an exception occurs during the compacting.
+     */
+    void compact(List<Path> inputFiles, CompactingFileWriter writer) throws Exception;
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/InputFormatBasedReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/InputFormatBasedReader.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.api.common.io.FileInputFormat;
+import org.apache.flink.core.fs.FileInputSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.function.SerializableSupplierWithException;
+
+import java.io.IOException;
+
+/**
+ * A {@link RecordWiseFileCompactor.Reader} implementation that reads the file using the {@link
+ * FileInputFormat}.
+ */
+public class InputFormatBasedReader<T> implements RecordWiseFileCompactor.Reader<T> {
+    private final Path path;
+    private final FileInputFormat<T> inputFormat;
+
+    public InputFormatBasedReader(Path path, FileInputFormat<T> inputFormat) throws IOException {
+        this.path = path;
+        this.inputFormat = inputFormat;
+        open();
+    }
+
+    private void open() throws IOException {
+        long len = path.getFileSystem().getFileStatus(path).getLen();
+        inputFormat.open(new FileInputSplit(0, path, 0, len, null));
+    }
+
+    @Override
+    public T read() throws IOException {
+        if (inputFormat.reachedEnd()) {
+            return null;
+        }
+        return inputFormat.nextRecord(null);
+    }
+
+    @Override
+    public void close() throws IOException {
+        inputFormat.close();
+    }
+
+    /** Factory for {@link InputFormatBasedReader}. */
+    public static class Factory<T> implements RecordWiseFileCompactor.Reader.Factory<T> {
+        private final SerializableSupplierWithException<FileInputFormat<T>, IOException>
+                inputFormatFactory;
+
+        public Factory(
+                SerializableSupplierWithException<FileInputFormat<T>, IOException>
+                        inputFormatFactory) {
+            this.inputFormatFactory = inputFormatFactory;
+        }
+
+        @Override
+        public InputFormatBasedReader<T> open(Path path) throws IOException {
+            return new InputFormatBasedReader<>(path, inputFormatFactory.get());
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/OutputStreamBasedFileCompactor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/OutputStreamBasedFileCompactor.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.functions.sink.filesystem.CompactingFileWriter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.OutputStreamBasedCompactingFileWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+/**
+ * Base class for {@link FileCompactor} implementations that use the {@link
+ * OutputStreamBasedCompactingFileWriter}.
+ */
+public abstract class OutputStreamBasedFileCompactor implements FileCompactor {
+    @Override
+    public final CompactingFileWriter.Type getWriterType() {
+        return CompactingFileWriter.Type.OUTPUT_STREAM;
+    }
+
+    @Override
+    public void compact(List<Path> inputFiles, CompactingFileWriter writer) throws Exception {
+        // The outputStream returned by OutputStreamBasedCompactingFileWriter#asOutputStream should
+        // not be closed here.
+        CloseShieldOutputStream outputStream =
+                new CloseShieldOutputStream(
+                        ((OutputStreamBasedCompactingFileWriter) writer).asOutputStream());
+        doCompact(inputFiles, outputStream);
+    }
+
+    protected abstract void doCompact(List<Path> inputFiles, OutputStream outputStream)
+            throws Exception;
+
+    // A utility class to prevent the enclosing OutputStream being closed.
+    private static class CloseShieldOutputStream extends OutputStream {
+        private final OutputStream out;
+
+        public CloseShieldOutputStream(OutputStream out) {
+            this.out = out;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            out.write(b);
+        }
+
+        @Override
+        public void write(byte[] buffer) throws IOException {
+            out.write(buffer);
+        }
+
+        @Override
+        public void write(byte[] buffer, int off, int len) throws IOException {
+            out.write(buffer, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            out.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            // Do not actually close the internal stream.
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/RecordWiseFileCompactor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/RecordWiseFileCompactor.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.streaming.api.functions.sink.filesystem.CompactingFileWriter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.RecordWiseCompactingFileWriter;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * A {@link FileCompactor} implementation that reads input files with a {@link Reader} and writes
+ * with the {@link RecordWiseCompactingFileWriter}.
+ */
+public class RecordWiseFileCompactor<IN> implements FileCompactor {
+    private final Reader.Factory<IN> readerFactory;
+
+    public RecordWiseFileCompactor(Reader.Factory<IN> readerFactory) {
+        this.readerFactory = readerFactory;
+    }
+
+    @Override
+    public final CompactingFileWriter.Type getWriterType() {
+        return CompactingFileWriter.Type.RECORD_WISE;
+    }
+
+    @Override
+    public void compact(List<Path> inputFiles, CompactingFileWriter writer) throws Exception {
+        RecordWiseCompactingFileWriter<IN> recordWriter =
+                (RecordWiseCompactingFileWriter<IN>) writer;
+        for (Path input : inputFiles) {
+            try (Reader<IN> reader = readerFactory.open(input)) {
+                IN elem;
+                while ((elem = reader.read()) != null) {
+                    recordWriter.write(elem);
+                }
+            }
+        }
+    }
+
+    /**
+     * The reader that reads record from the compacting files.
+     *
+     * @param <T> Thy type of the records that is read.
+     */
+    public interface Reader<T> extends AutoCloseable {
+
+        /** @return The next record, or null if no more available. */
+        T read() throws IOException;
+
+        /**
+         * Factory for {@link Reader}.
+         *
+         * @param <T> Thy type of the records that is read.
+         */
+        interface Factory<T> extends Serializable {
+            /**
+             * @return A reader that reads elements from the given file.
+             * @throws IOException Thrown if an I/O error occurs when opening the file.
+             */
+            Reader<T> open(Path path) throws IOException;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinator.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor.operator;
+
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.connector.file.sink.compactor.FileCompactStrategy;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter.PendingFileRecoverable;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Coordinator that coordinates file compaction for the {@link FileSink}.
+ *
+ * <p>All committable emitted from the writers are collected and packed into {@link
+ * CompactorRequest}s. The {@link FileCompactStrategy} defines when the requests can be fired. When
+ * a firing condition is met, the requests will be sent to the {@link CompactorOperator}.
+ *
+ * <p>The {@link CompactCoordinator} stores the non-fired committable as its state, and may emit a
+ * request at any time. A {@link CompactorOperator} must ensure that the ownership of the
+ * committable in a compact request is successfully handed from the coordinator, before it can
+ * actually perform the compaction.
+ */
+public class CompactCoordinator extends AbstractStreamOperator<CompactorRequest>
+        implements OneInputStreamOperator<
+                        CommittableMessage<FileSinkCommittable>, CompactorRequest>,
+                BoundedOneInput {
+
+    private static final ListStateDescriptor<byte[]> REMAINING_COMMITTABLE_RAW_STATES_DESC =
+            new ListStateDescriptor<>(
+                    "remaining_compact_commt_raw_state", BytePrimitiveArraySerializer.INSTANCE);
+
+    private final FileCompactStrategy strategy;
+    private final SimpleVersionedSerializer<FileSinkCommittable> committableSerializer;
+
+    private final Map<String, CompactorRequest> packing = new HashMap<>();
+    private final Map<String, CompactTrigger> triggers = new HashMap<>();
+
+    private ListState<FileSinkCommittable> remainingCommittableState;
+
+    public CompactCoordinator(
+            FileCompactStrategy strategy,
+            SimpleVersionedSerializer<FileSinkCommittable> committableSerializer) {
+        this.strategy = strategy;
+        this.committableSerializer = checkNotNull(committableSerializer);
+    }
+
+    @Override
+    public void processElement(StreamRecord<CommittableMessage<FileSinkCommittable>> element)
+            throws Exception {
+        CommittableMessage<FileSinkCommittable> message = element.getValue();
+        if (message instanceof CommittableWithLineage) {
+            FileSinkCommittable committable =
+                    ((CommittableWithLineage<FileSinkCommittable>) element.getValue())
+                            .getCommittable();
+            String bucketId = committable.getBucketId();
+            if (packAndTrigger(bucketId, committable)) {
+                fireAndPurge(bucketId);
+            }
+        }
+        // or message instanceof CommittableSummary
+        // info in CommittableSummary is not necessary for compacting at present, ignore it
+    }
+
+    private boolean packAndTrigger(String bucketId, FileSinkCommittable committable) {
+        CompactorRequest bucketRequest = packing.computeIfAbsent(bucketId, CompactorRequest::new);
+        if (committable.hasInProgressFileToCleanup() || committable.hasCompactedFileToCleanup()) {
+            // cleanup request, pass through directly
+            bucketRequest.addToPassthrough(committable);
+            return false;
+        }
+
+        if (!committable.hasPendingFile()) {
+            throw new RuntimeException("Committable to compact has no content.");
+        }
+
+        CompactTrigger trigger =
+                triggers.computeIfAbsent(bucketId, id -> new CompactTrigger(strategy));
+        CompactTriggerResult triggerResult = trigger.onElement(committable);
+        switch (triggerResult) {
+            case PASS_THROUGH:
+                bucketRequest.addToPassthrough(committable);
+                return false;
+            case CONTINUE:
+                bucketRequest.addToCompact(committable);
+                return false;
+            case FIRE_AND_PURGE:
+                bucketRequest.addToCompact(committable);
+                return true;
+            default:
+                throw new RuntimeException("Unexpected trigger result:" + triggerResult);
+        }
+    }
+
+    private void fireAndPurge(String bucketId) {
+        triggers.remove(bucketId);
+        CompactorRequest request = packing.remove(bucketId);
+        if (request != null) {
+            output.collect(new StreamRecord<>(request));
+        }
+    }
+
+    @Override
+    public void endInput() throws Exception {
+        // emit all requests remained
+        for (CompactorRequest request : packing.values()) {
+            output.collect(new StreamRecord<>(request));
+        }
+        packing.clear();
+        triggers.clear();
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+        super.prepareSnapshotPreBarrier(checkpointId);
+
+        // trigger on checkpoint
+        List<String> bucketsToFire = new ArrayList<>(triggers.size());
+        for (Map.Entry<String, CompactTrigger> e : triggers.entrySet()) {
+            String bucketId = e.getKey();
+            CompactTrigger trigger = e.getValue();
+            if (trigger.onCheckpoint(checkpointId) == CompactTriggerResult.FIRE_AND_PURGE) {
+                bucketsToFire.add(bucketId);
+            }
+        }
+        bucketsToFire.forEach(this::fireAndPurge);
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        super.snapshotState(context);
+
+        List<FileSinkCommittable> remainingCommittable =
+                packing.values().stream()
+                        .flatMap(r -> r.getCommittableToCompact().stream())
+                        .collect(Collectors.toList());
+        packing.values().stream()
+                .flatMap(r -> r.getCommittableToPassthrough().stream())
+                .forEach(remainingCommittable::add);
+        remainingCommittableState.update(remainingCommittable);
+
+        // triggers will be recomputed when restoring so it's not necessary to store
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+
+        remainingCommittableState =
+                new SimpleVersionedListState<>(
+                        context.getOperatorStateStore()
+                                .getListState(REMAINING_COMMITTABLE_RAW_STATES_DESC),
+                        committableSerializer);
+
+        Iterable<FileSinkCommittable> stateRemaining = remainingCommittableState.get();
+        if (stateRemaining != null) {
+            for (FileSinkCommittable committable : stateRemaining) {
+                // restore and redistribute
+                String bucketId = committable.getBucketId();
+                if (packAndTrigger(bucketId, committable)) {
+                    fireAndPurge(bucketId);
+                }
+            }
+        }
+    }
+
+    enum CompactTriggerResult {
+        CONTINUE,
+        FIRE_AND_PURGE,
+        PASS_THROUGH
+    }
+
+    private static class CompactTrigger {
+        private final long threshold;
+        private final boolean compactOnCheckpoint;
+
+        private long size;
+
+        CompactTrigger(FileCompactStrategy strategy) {
+            this.threshold = strategy.getSizeThreshold();
+            this.compactOnCheckpoint = strategy.isCompactOnCheckpoint();
+        }
+
+        public CompactTriggerResult onElement(FileSinkCommittable committable) {
+            if (threshold < 0) {
+                return CompactTriggerResult.CONTINUE;
+            }
+
+            PendingFileRecoverable file = committable.getPendingFile();
+            if (file == null) {
+                return CompactTriggerResult.PASS_THROUGH;
+            }
+
+            long curSize = file.getSize();
+            if (curSize < 0) {
+                // unrecognized committable, can not compact, pass through directly
+                return CompactTriggerResult.PASS_THROUGH;
+            }
+
+            size += curSize;
+            return size >= threshold
+                    ? CompactTriggerResult.FIRE_AND_PURGE
+                    : CompactTriggerResult.CONTINUE;
+        }
+
+        public CompactTriggerResult onCheckpoint(long checkpointId) {
+            return compactOnCheckpoint
+                    ? CompactTriggerResult.FIRE_AND_PURGE
+                    : CompactTriggerResult.CONTINUE;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinatorFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactCoordinatorFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor.operator;
+
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.connector.file.sink.compactor.FileCompactStrategy;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+/** Factory for {@link CompactCoordinator}. */
+public class CompactCoordinatorFactory extends AbstractStreamOperatorFactory<CompactorRequest>
+        implements OneInputStreamOperatorFactory<
+                CommittableMessage<FileSinkCommittable>, CompactorRequest> {
+
+    private final FileSink<?> sink;
+    private final FileCompactStrategy strategy;
+
+    public CompactCoordinatorFactory(FileSink<?> sink, FileCompactStrategy strategy) {
+        this.sink = sink;
+        this.strategy = strategy;
+    }
+
+    @Override
+    public <T extends StreamOperator<CompactorRequest>> T createStreamOperator(
+            StreamOperatorParameters<CompactorRequest> parameters) {
+        try {
+            final CompactCoordinator compactOperator =
+                    new CompactCoordinator(strategy, sink.getCommittableSerializer());
+            compactOperator.setup(
+                    parameters.getContainingTask(),
+                    parameters.getStreamConfig(),
+                    parameters.getOutput());
+            return (T) compactOperator;
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Cannot create commit operator for "
+                            + parameters.getStreamConfig().getOperatorName(),
+                    e);
+        }
+    }
+
+    @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+        return CompactCoordinator.class;
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperator.java
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor.operator;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.connector.file.sink.compactor.FileCompactor;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.runtime.util.Hardware;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketWriter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.CompactingFileWriter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter.PendingFileRecoverable;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.BoundedOneInput;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+/**
+ * An operator that perform compaction for the {@link FileSink}.
+ *
+ * <p>Requests received from the {@link CompactCoordinator} will firstly be held in memory, and
+ * snapshot into the state of a checkpoint. When the checkpoint is successfully completed, all
+ * requests received before can be submitted. The results can be emitted at the next {@link
+ * #prepareSnapshotPreBarrier} invoking after the compaction is finished, to ensure that committers
+ * can receive only one CommittableSummary and the corresponding number of Committable for a single
+ * checkpoint.
+ */
+public class CompactorOperator
+        extends AbstractStreamOperator<CommittableMessage<FileSinkCommittable>>
+        implements OneInputStreamOperator<
+                        CompactorRequest, CommittableMessage<FileSinkCommittable>>,
+                BoundedOneInput,
+                CheckpointListener {
+
+    private static final String COMPACTED_PREFIX = "compacted-";
+    private static final long SUBMITTED_ID = -1L;
+
+    private static final ListStateDescriptor<byte[]> REMAINING_REQUESTS_RAW_STATES_DESC =
+            new ListStateDescriptor<>(
+                    "remaining_requests_raw_state", BytePrimitiveArraySerializer.INSTANCE);
+
+    private final int compactThreads;
+    private final SimpleVersionedSerializer<FileSinkCommittable> committableSerializer;
+
+    private final FileCompactor fileCompactor;
+    private final BucketWriter<?, String> bucketWriter;
+
+    private transient ExecutorService compactService;
+
+    private List<CompactorRequest> collectingRequests = new ArrayList<>();
+    private final TreeMap<Long, List<CompactorRequest>> snapshotRequests = new TreeMap<>();
+    private final List<Tuple2<CompactorRequest, CompletableFuture<Iterable<FileSinkCommittable>>>>
+            compactingRequests = new LinkedList<>();
+
+    private ListState<Map<Long, List<CompactorRequest>>> remainingRequestsState;
+
+    public CompactorOperator(
+            int compactThreads,
+            SimpleVersionedSerializer<FileSinkCommittable> committableSerializer,
+            FileCompactor fileCompactor,
+            BucketWriter<?, String> bucketWriter) {
+        this.compactThreads = compactThreads;
+        this.committableSerializer = committableSerializer;
+        this.fileCompactor = fileCompactor;
+        this.bucketWriter = bucketWriter;
+    }
+
+    @Override
+    public void open() throws Exception {
+        super.open();
+        this.compactService =
+                Executors.newFixedThreadPool(
+                        Math.max(1, Math.min(compactThreads, Hardware.getNumberCPUCores())),
+                        new ExecutorThreadFactory("compact-executor"));
+    }
+
+    @Override
+    public void processElement(StreamRecord<CompactorRequest> element) throws Exception {
+        collectingRequests.add(element.getValue());
+    }
+
+    @Override
+    public void endInput() throws Exception {
+        // add collecting requests into the final snapshot
+        snapshotRequests.put(Long.MAX_VALUE, collectingRequests);
+        collectingRequests = new ArrayList<>();
+
+        // submit all requests and wait until they are done
+        submitUntil(Long.MAX_VALUE);
+        assert snapshotRequests.isEmpty();
+
+        getAllTasksFuture().join();
+        emitCompacted(null);
+        assert compactingRequests.isEmpty();
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        super.notifyCheckpointComplete(checkpointId);
+        submitUntil(checkpointId);
+    }
+
+    @Override
+    public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {
+        emitCompacted(checkpointId);
+    }
+
+    @Override
+    public void snapshotState(StateSnapshotContext context) throws Exception {
+        super.snapshotState(context);
+
+        // add collecting requests during the checkpoint into the snapshot
+        snapshotRequests.put(context.getCheckpointId(), collectingRequests);
+        collectingRequests = new ArrayList<>();
+
+        // snapshot all compacting requests as well, including the requests that are not finished
+        // when invoking prepareSnapshotPreBarrier but finished now, since they are not emitted yet
+        Map<Long, List<CompactorRequest>> requests = new HashMap<>(snapshotRequests);
+        requests.computeIfAbsent(SUBMITTED_ID, id -> new ArrayList<>())
+                .addAll(compactingRequests.stream().map(r -> r.f0).collect(Collectors.toList()));
+        remainingRequestsState.update(Collections.singletonList(requests));
+    }
+
+    @Override
+    public void initializeState(StateInitializationContext context) throws Exception {
+        super.initializeState(context);
+
+        remainingRequestsState =
+                new SimpleVersionedListState<>(
+                        context.getOperatorStateStore()
+                                .getListState(REMAINING_REQUESTS_RAW_STATES_DESC),
+                        new RemainingRequestsSerializer(
+                                new CompactorRequestSerializer(committableSerializer)));
+
+        Iterable<Map<Long, List<CompactorRequest>>> stateRemaining = remainingRequestsState.get();
+        if (stateRemaining != null) {
+            for (Map<Long, List<CompactorRequest>> requests : stateRemaining) {
+                // elements can be more than one when redistributed after parallelism changing
+                for (Map.Entry<Long, List<CompactorRequest>> e : requests.entrySet()) {
+                    List<CompactorRequest> list =
+                            snapshotRequests.computeIfAbsent(e.getKey(), id -> new ArrayList<>());
+                    list.addAll(e.getValue());
+                }
+            }
+        }
+        // submit all requests that is already submitted before this checkpoint
+        submitUntil(SUBMITTED_ID);
+    }
+
+    private void submitUntil(long checkpointId) {
+        NavigableMap<Long, List<CompactorRequest>> canSubmit =
+                snapshotRequests.subMap(Long.MIN_VALUE, true, checkpointId, true);
+        Iterator<Entry<Long, List<CompactorRequest>>> iter = canSubmit.entrySet().iterator();
+        while (iter.hasNext()) {
+            Entry<Long, List<CompactorRequest>> requestEntry = iter.next();
+            for (CompactorRequest req : requestEntry.getValue()) {
+                CompletableFuture<Iterable<FileSinkCommittable>> resultFuture =
+                        new CompletableFuture<>();
+                compactingRequests.add(new Tuple2<>(req, resultFuture));
+                compactService.submit(
+                        () -> {
+                            try {
+                                Iterable<FileSinkCommittable> result = compact(req);
+                                resultFuture.complete(result);
+                            } catch (Exception e) {
+                                resultFuture.completeExceptionally(e);
+                            }
+                        });
+            }
+            iter.remove();
+        }
+    }
+
+    private Iterable<FileSinkCommittable> compact(CompactorRequest request) throws Exception {
+        List<FileSinkCommittable> results = new ArrayList<>(request.getCommittableToPassthrough());
+
+        List<Path> compactingFiles = getCompactingPath(request, results);
+        if (compactingFiles.isEmpty()) {
+            return results;
+        }
+
+        Path targetPath = assembleCompactedFilePath(compactingFiles.get(0));
+        CompactingFileWriter compactingFileWriter =
+                bucketWriter.openNewCompactingFile(
+                        fileCompactor.getWriterType(),
+                        request.getBucketId(),
+                        targetPath,
+                        System.currentTimeMillis());
+        fileCompactor.compact(compactingFiles, compactingFileWriter);
+        PendingFileRecoverable compactedPendingFile = compactingFileWriter.closeForCommit();
+
+        FileSinkCommittable compacted =
+                new FileSinkCommittable(request.getBucketId(), compactedPendingFile);
+        results.add(0, compacted);
+        for (Path f : compactingFiles) {
+            // cleanup compacted files
+            results.add(new FileSinkCommittable(request.getBucketId(), f));
+        }
+
+        return results;
+    }
+
+    // results: side output pass through committable
+    private List<Path> getCompactingPath(
+            CompactorRequest request, List<FileSinkCommittable> results) throws IOException {
+        List<FileSinkCommittable> compactingCommittable = request.getCommittableToCompact();
+        List<Path> compactingFiles = new ArrayList<>();
+
+        for (FileSinkCommittable committable : compactingCommittable) {
+            PendingFileRecoverable pendingFile = committable.getPendingFile();
+            if (pendingFile == null
+                    || pendingFile.getPath() == null
+                    || !pendingFile.getPath().getName().startsWith(".")) {
+                // the file may be written with writer of elder version, or
+                // the file will be visible once committed, so it can not be compacted.
+                // pass through, add to results, do not add to compacting files
+                results.add(committable);
+            } else {
+                // commit the pending file and compact the committed file
+                bucketWriter.recoverPendingFile(committable.getPendingFile()).commitAfterRecovery();
+                compactingFiles.add(committable.getPendingFile().getPath());
+            }
+        }
+        return compactingFiles;
+    }
+
+    private static Path assembleCompactedFilePath(Path uncompactedPath) {
+        String uncompactedName = uncompactedPath.getName();
+        if (uncompactedName.startsWith(".")) {
+            uncompactedName = uncompactedName.substring(1);
+        }
+        return new Path(uncompactedPath.getParent(), COMPACTED_PREFIX + uncompactedName);
+    }
+
+    private void emitCompacted(@Nullable Long checkpointId) throws Exception {
+        List<FileSinkCommittable> compacted = new ArrayList<>();
+        Iterator<Tuple2<CompactorRequest, CompletableFuture<Iterable<FileSinkCommittable>>>> iter =
+                compactingRequests.iterator();
+        while (iter.hasNext()) {
+            Tuple2<CompactorRequest, CompletableFuture<Iterable<FileSinkCommittable>>> compacting =
+                    iter.next();
+            CompletableFuture<Iterable<FileSinkCommittable>> future = compacting.f1;
+            if (future.isDone()) {
+                iter.remove();
+                // Exception is thrown if it's completed exceptionally
+                for (FileSinkCommittable c : future.get()) {
+                    compacted.add(c);
+                }
+            }
+        }
+
+        if (compacted.isEmpty()) {
+            return;
+        }
+
+        // A summary must be sent before all results during this checkpoint
+        CommittableSummary<FileSinkCommittable> summary =
+                new CommittableSummary<>(
+                        getRuntimeContext().getIndexOfThisSubtask(),
+                        getRuntimeContext().getNumberOfParallelSubtasks(),
+                        checkpointId,
+                        compacted.size(),
+                        compacted.size(),
+                        0);
+        output.collect(new StreamRecord<>(summary));
+        for (FileSinkCommittable c : compacted) {
+            CommittableWithLineage<FileSinkCommittable> comm =
+                    new CommittableWithLineage<>(
+                            c, checkpointId, getRuntimeContext().getIndexOfThisSubtask());
+            output.collect(new StreamRecord<>(comm));
+        }
+    }
+
+    @VisibleForTesting
+    public CompletableFuture<?> getAllTasksFuture() {
+        return CompletableFuture.allOf(
+                compactingRequests.stream().map(r -> r.f1).toArray(CompletableFuture[]::new));
+    }
+
+    private static class RemainingRequestsSerializer
+            implements SimpleVersionedSerializer<Map<Long, List<CompactorRequest>>> {
+
+        private static final int MAGIC_NUMBER = 0xa946be83;
+
+        private final CompactorRequestSerializer requestSerializer;
+
+        private RemainingRequestsSerializer(CompactorRequestSerializer requestSerializer) {
+            this.requestSerializer = requestSerializer;
+        }
+
+        @Override
+        public int getVersion() {
+            return 1;
+        }
+
+        @Override
+        public byte[] serialize(Map<Long, List<CompactorRequest>> remainingRequests)
+                throws IOException {
+            DataOutputSerializer out = new DataOutputSerializer(256);
+            out.writeInt(MAGIC_NUMBER);
+            serializeV1(remainingRequests, out);
+            return out.getCopyOfBuffer();
+        }
+
+        @Override
+        public Map<Long, List<CompactorRequest>> deserialize(int version, byte[] serialized)
+                throws IOException {
+            DataInputDeserializer in = new DataInputDeserializer(serialized);
+
+            switch (version) {
+                case 1:
+                    validateMagicNumber(in);
+                    return deserializeV1(in);
+                default:
+                    throw new IOException("Unrecognized version or corrupt state: " + version);
+            }
+        }
+
+        private void serializeV1(
+                Map<Long, List<CompactorRequest>> request, DataOutputSerializer out)
+                throws IOException {
+            out.writeInt(request.size());
+            for (Map.Entry<Long, List<CompactorRequest>> e : request.entrySet()) {
+                out.writeLong(e.getKey());
+                SimpleVersionedSerialization.writeVersionAndSerializeList(
+                        requestSerializer, e.getValue(), out);
+            }
+        }
+
+        private Map<Long, List<CompactorRequest>> deserializeV1(DataInputDeserializer in)
+                throws IOException {
+            int size = in.readInt();
+            Map<Long, List<CompactorRequest>> requestMap = new HashMap<>(size);
+            for (int i = 0; i < size; i++) {
+                long cpId = in.readLong();
+                List<CompactorRequest> requests =
+                        SimpleVersionedSerialization.readVersionAndDeserializeList(
+                                requestSerializer, in);
+                requestMap.put(cpId, requests);
+            }
+            return requestMap;
+        }
+
+        private static void validateMagicNumber(DataInputView in) throws IOException {
+            int magicNumber = in.readInt();
+            if (magicNumber != MAGIC_NUMBER) {
+                throw new IOException(
+                        String.format("Corrupt data: Unexpected magic number %08X", magicNumber));
+            }
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorOperatorFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor.operator;
+
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.connector.file.sink.compactor.FileCompactStrategy;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+/** Factory for {@link CompactorOperator}. */
+public class CompactorOperatorFactory
+        extends AbstractStreamOperatorFactory<CommittableMessage<FileSinkCommittable>>
+        implements OneInputStreamOperatorFactory<
+                CompactorRequest, CommittableMessage<FileSinkCommittable>> {
+
+    private final FileSink<?> sink;
+    private final FileCompactStrategy strategy;
+
+    public CompactorOperatorFactory(FileSink<?> sink, FileCompactStrategy strategy) {
+        this.sink = sink;
+        this.strategy = strategy;
+    }
+
+    @Override
+    public <T extends StreamOperator<CommittableMessage<FileSinkCommittable>>>
+            T createStreamOperator(
+                    StreamOperatorParameters<CommittableMessage<FileSinkCommittable>> parameters) {
+        try {
+            final CompactorOperator compactOperator =
+                    new CompactorOperator(
+                            strategy.getCompactThread(), sink.getCommittableSerializer(),
+                            sink.getFileCompactor(), sink.createBucketWriter());
+            compactOperator.setup(
+                    parameters.getContainingTask(),
+                    parameters.getStreamConfig(),
+                    parameters.getOutput());
+            return (T) compactOperator;
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Cannot create commit operator for "
+                            + parameters.getStreamConfig().getOperatorName(),
+                    e);
+        }
+    }
+
+    @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+        return CompactorOperator.class;
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequest.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor.operator;
+
+import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Request of file compacting for {@link FileSink}. */
+public class CompactorRequest implements Serializable {
+    private final String bucketId;
+    private final List<FileSinkCommittable> committableToCompact;
+    private final List<FileSinkCommittable> committableToPassthrough;
+
+    public CompactorRequest(String bucketId) {
+        this.bucketId = bucketId;
+        this.committableToCompact = new ArrayList<>();
+        this.committableToPassthrough = new ArrayList<>();
+    }
+
+    public CompactorRequest(
+            String bucketId,
+            List<FileSinkCommittable> committableToCompact,
+            List<FileSinkCommittable> committableToPassthrough) {
+        this.bucketId = bucketId;
+        this.committableToCompact = committableToCompact;
+        this.committableToPassthrough = committableToPassthrough;
+    }
+
+    public void addToCompact(FileSinkCommittable committable) {
+        committableToCompact.add(committable);
+    }
+
+    public void addToPassthrough(FileSinkCommittable committable) {
+        committableToPassthrough.add(committable);
+    }
+
+    public String getBucketId() {
+        return bucketId;
+    }
+
+    public List<FileSinkCommittable> getCommittableToCompact() {
+        return committableToCompact;
+    }
+
+    public List<FileSinkCommittable> getCommittableToPassthrough() {
+        return committableToPassthrough;
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestSerializer.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestSerializer.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor.operator;
+
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.core.io.SimpleVersionedSerialization;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataInputDeserializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputSerializer;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Versioned serializer for {@link CompactorRequest}. */
+public class CompactorRequestSerializer implements SimpleVersionedSerializer<CompactorRequest> {
+
+    private final SimpleVersionedSerializer<FileSinkCommittable> committableSerializer;
+
+    private static final int MAGIC_NUMBER = 0x2fc61e19;
+
+    public CompactorRequestSerializer(
+            SimpleVersionedSerializer<FileSinkCommittable> committableSerializer) {
+        this.committableSerializer = committableSerializer;
+    }
+
+    @Override
+    public int getVersion() {
+        return 1;
+    }
+
+    @Override
+    public byte[] serialize(CompactorRequest request) throws IOException {
+        DataOutputSerializer out = new DataOutputSerializer(256);
+        out.writeInt(MAGIC_NUMBER);
+        serializeV1(request, out);
+        return out.getCopyOfBuffer();
+    }
+
+    @Override
+    public CompactorRequest deserialize(int version, byte[] serialized) throws IOException {
+        DataInputDeserializer in = new DataInputDeserializer(serialized);
+
+        switch (version) {
+            case 1:
+                validateMagicNumber(in);
+                return deserializeV1(in);
+            default:
+                throw new IOException("Unrecognized version or corrupt state: " + version);
+        }
+    }
+
+    private void serializeV1(CompactorRequest request, DataOutputSerializer out)
+            throws IOException {
+        out.writeUTF(request.getBucketId());
+        SimpleVersionedSerialization.writeVersionAndSerializeList(
+                committableSerializer, request.getCommittableToCompact(), out);
+        SimpleVersionedSerialization.writeVersionAndSerializeList(
+                committableSerializer, request.getCommittableToPassthrough(), out);
+    }
+
+    private CompactorRequest deserializeV1(DataInputDeserializer in) throws IOException {
+        String bucketId = in.readUTF();
+        List<FileSinkCommittable> committableToCompact =
+                SimpleVersionedSerialization.readVersionAndDeserializeList(
+                        committableSerializer, in);
+        List<FileSinkCommittable> committableToPassthrough =
+                SimpleVersionedSerialization.readVersionAndDeserializeList(
+                        committableSerializer, in);
+        return new CompactorRequest(bucketId, committableToCompact, committableToPassthrough);
+    }
+
+    private static void validateMagicNumber(DataInputView in) throws IOException {
+        int magicNumber = in.readInt();
+        if (magicNumber != MAGIC_NUMBER) {
+            throw new IOException(
+                    String.format("Corrupt data: Unexpected magic number %08X", magicNumber));
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestTypeInfo.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/compactor/operator/CompactorRequestTypeInfo.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor.operator;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializerTypeSerializerProxy;
+import org.apache.flink.util.function.SerializableSupplierWithException;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/** Type information of {@link CompactorRequest}. Unsuitable for state. */
+public class CompactorRequestTypeInfo extends TypeInformation<CompactorRequest> {
+
+    private final SerializableSupplierWithException<
+                    SimpleVersionedSerializer<FileSinkCommittable>, IOException>
+            committableSerializerSupplier;
+
+    public CompactorRequestTypeInfo(
+            SerializableSupplierWithException<
+                            SimpleVersionedSerializer<FileSinkCommittable>, IOException>
+                    committableSerializerSupplier) {
+        this.committableSerializerSupplier = committableSerializerSupplier;
+    }
+
+    @Override
+    public boolean isBasicType() {
+        return false;
+    }
+
+    @Override
+    public boolean isTupleType() {
+        return false;
+    }
+
+    @Override
+    public int getArity() {
+        return 0;
+    }
+
+    @Override
+    public int getTotalFields() {
+        return 0;
+    }
+
+    @Override
+    public Class<CompactorRequest> getTypeClass() {
+        return CompactorRequest.class;
+    }
+
+    @Override
+    public boolean isKeyType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<CompactorRequest> createSerializer(ExecutionConfig config) {
+        return new SimpleVersionedSerializerTypeSerializerProxy<>(
+                () -> new CompactorRequestSerializer(createCommittableSerializer()));
+    }
+
+    @Override
+    public String toString() {
+        return "CompactorRequestTypeInfo{" + "serializer=" + createCommittableSerializer() + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || !canEqual(o)) {
+            return false;
+        }
+        CompactorRequestTypeInfo that = (CompactorRequestTypeInfo) o;
+        return Objects.equals(
+                createCommittableSerializer().getClass(),
+                that.createCommittableSerializer().getClass());
+    }
+
+    @Override
+    public boolean canEqual(Object obj) {
+        return obj instanceof CompactorRequestTypeInfo;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(createCommittableSerializer().getClass());
+    }
+
+    private SimpleVersionedSerializer<FileSinkCommittable> createCommittableSerializer() {
+        try {
+            return committableSerializerSupplier.get();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/FileWriterBucket.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/FileWriterBucket.java
@@ -202,11 +202,12 @@ class FileWriterBucket<IN> {
         }
 
         List<FileSinkCommittable> committables = new ArrayList<>();
-        pendingFiles.forEach(pendingFile -> committables.add(new FileSinkCommittable(pendingFile)));
+        pendingFiles.forEach(
+                pendingFile -> committables.add(new FileSinkCommittable(bucketId, pendingFile)));
         pendingFiles.clear();
 
         if (inProgressFileToCleanup != null) {
-            committables.add(new FileSinkCommittable(inProgressFileToCleanup));
+            committables.add(new FileSinkCommittable(bucketId, inProgressFileToCleanup));
             inProgressFileToCleanup = null;
         }
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileCommittableSerializerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/FileCommittableSerializerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.file.sink;
 
 import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils;
+import org.apache.flink.core.fs.Path;
 
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -36,23 +37,43 @@ public class FileCommittableSerializerTest {
     @Test
     public void testCommittableWithPendingFile() throws IOException {
         FileSinkCommittable committable =
-                new FileSinkCommittable(new FileSinkTestUtils.TestPendingFileRecoverable());
+                new FileSinkCommittable("0", new FileSinkTestUtils.TestPendingFileRecoverable());
         FileSinkCommittable deserialized = serializeAndDeserialize(committable);
+        assertEquals(committable.getBucketId(), deserialized.getBucketId());
         assertEquals(committable.getPendingFile(), deserialized.getPendingFile());
         assertEquals(
                 committable.getInProgressFileToCleanup(),
                 deserialized.getInProgressFileToCleanup());
+        assertEquals(
+                committable.getCompactedFileToCleanup(), deserialized.getCompactedFileToCleanup());
     }
 
     @Test
     public void testCommittableWithInProgressFileToCleanup() throws IOException {
         FileSinkCommittable committable =
-                new FileSinkCommittable(new FileSinkTestUtils.TestInProgressFileRecoverable());
+                new FileSinkCommittable("0", new FileSinkTestUtils.TestInProgressFileRecoverable());
         FileSinkCommittable deserialized = serializeAndDeserialize(committable);
+        assertEquals(committable.getBucketId(), deserialized.getBucketId());
         assertEquals(committable.getPendingFile(), deserialized.getPendingFile());
         assertEquals(
                 committable.getInProgressFileToCleanup(),
                 deserialized.getInProgressFileToCleanup());
+        assertEquals(
+                committable.getCompactedFileToCleanup(), deserialized.getCompactedFileToCleanup());
+    }
+
+    @Test
+    public void testCommittableWithCompactedFileToCleanup() throws IOException {
+        FileSinkCommittable committable =
+                new FileSinkCommittable("0", new Path("/tmp/mock_path_to_cleanup"));
+        FileSinkCommittable deserialized = serializeAndDeserialize(committable);
+        assertEquals(committable.getBucketId(), deserialized.getBucketId());
+        assertEquals(committable.getPendingFile(), deserialized.getPendingFile());
+        assertEquals(
+                committable.getInProgressFileToCleanup(),
+                deserialized.getInProgressFileToCleanup());
+        assertEquals(
+                committable.getCompactedFileToCleanup(), deserialized.getCompactedFileToCleanup());
     }
 
     private FileSinkCommittable serializeAndDeserialize(FileSinkCommittable committable)

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/committer/FileCommitterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/committer/FileCommitterTest.java
@@ -50,7 +50,7 @@ public class FileCommitterTest {
         MockCommitRequest<FileSinkCommittable> fileSinkCommittable =
                 new MockCommitRequest<>(
                         new FileSinkCommittable(
-                                new FileSinkTestUtils.TestPendingFileRecoverable()));
+                                "0", new FileSinkTestUtils.TestPendingFileRecoverable()));
         fileCommitter.commit(Collections.singletonList(fileSinkCommittable));
 
         assertEquals(1, stubBucketWriter.getRecoveredPendingFiles().size());
@@ -67,7 +67,7 @@ public class FileCommitterTest {
         MockCommitRequest<FileSinkCommittable> fileSinkCommittable =
                 new MockCommitRequest<>(
                         new FileSinkCommittable(
-                                new FileSinkTestUtils.TestInProgressFileRecoverable()));
+                                "0", new FileSinkTestUtils.TestInProgressFileRecoverable()));
         fileCommitter.commit(Collections.singletonList(fileSinkCommittable));
 
         assertEquals(0, stubBucketWriter.getRecoveredPendingFiles().size());
@@ -83,15 +83,15 @@ public class FileCommitterTest {
         Collection<CommitRequest<FileSinkCommittable>> committables =
                 Stream.of(
                                 new FileSinkCommittable(
-                                        new FileSinkTestUtils.TestPendingFileRecoverable()),
+                                        "0", new FileSinkTestUtils.TestPendingFileRecoverable()),
                                 new FileSinkCommittable(
-                                        new FileSinkTestUtils.TestPendingFileRecoverable()),
+                                        "0", new FileSinkTestUtils.TestPendingFileRecoverable()),
                                 new FileSinkCommittable(
-                                        new FileSinkTestUtils.TestInProgressFileRecoverable()),
+                                        "0", new FileSinkTestUtils.TestInProgressFileRecoverable()),
                                 new FileSinkCommittable(
-                                        new FileSinkTestUtils.TestPendingFileRecoverable()),
+                                        "0", new FileSinkTestUtils.TestPendingFileRecoverable()),
                                 new FileSinkCommittable(
-                                        new FileSinkTestUtils.TestInProgressFileRecoverable()))
+                                        "0", new FileSinkTestUtils.TestInProgressFileRecoverable()))
                         .map(MockCommitRequest::new)
                         .collect(Collectors.toList());
         fileCommitter.commit(committables);

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/AbstractCompactTestBase.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/AbstractCompactTestBase.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.core.fs.Path;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+/** Test base for compact operators. */
+public abstract class AbstractCompactTestBase {
+
+    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+    public static final int TARGET_SIZE = 9;
+
+    Path folder;
+
+    @Before
+    public void before() throws IOException {
+        folder = new Path(TEMP_FOLDER.newFolder().getPath());
+    }
+
+    Path newFile(String name, int len) throws IOException {
+        Path path = new Path(folder, name);
+        File file = new File(path.getPath());
+        file.delete();
+        file.createNewFile();
+
+        try (FileOutputStream out = new FileOutputStream(file)) {
+            for (int i = 0; i < len; i++) {
+                out.write(i);
+            }
+        }
+        return path;
+    }
+}

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactCoordinatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactCoordinatorTest.java
@@ -1,0 +1,322 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.connector.file.sink.FileSinkCommittableSerializer;
+import org.apache.flink.connector.file.sink.compactor.FileCompactStrategy.Builder;
+import org.apache.flink.connector.file.sink.compactor.operator.CompactCoordinator;
+import org.apache.flink.connector.file.sink.compactor.operator.CompactorRequest;
+import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils;
+import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils.TestInProgressFileRecoverable;
+import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils.TestPendingFileRecoverable;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+/** Test for {@link CompactCoordinator}. */
+public class CompactCoordinatorTest extends AbstractCompactTestBase {
+
+    @Test
+    public void testSizeThreshold() throws Exception {
+        FileCompactStrategy strategy = Builder.newBuilder().withSizeThreshold(10).build();
+        CompactCoordinator coordinator =
+                new CompactCoordinator(strategy, getTestCommittableSerializer());
+
+        try (OneInputStreamOperatorTestHarness<
+                        CommittableMessage<FileSinkCommittable>, CompactorRequest>
+                harness = new OneInputStreamOperatorTestHarness<>(coordinator)) {
+            harness.setup();
+            harness.open();
+
+            FileSinkCommittable committable0 = committable("0", "0", 5);
+            FileSinkCommittable committable1 = committable("0", "1", 6);
+            harness.processElement(message(committable0));
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+
+            harness.processElement(message(committable1));
+
+            List<CompactorRequest> results = harness.extractOutputValues();
+            Assert.assertEquals(1, results.size());
+            assertToCompact(results.get(0), committable0, committable1);
+
+            harness.processElement(message(committable("0", "2", 5)));
+            harness.processElement(message(committable("1", "0", 5)));
+
+            Assert.assertEquals(1, harness.extractOutputValues().size());
+        }
+    }
+
+    @Test
+    public void testCompactOnCheckpoint() throws Exception {
+        FileCompactStrategy strategy = Builder.newBuilder().setCompactOnCheckpoint(true).build();
+        CompactCoordinator coordinator =
+                new CompactCoordinator(strategy, getTestCommittableSerializer());
+
+        try (OneInputStreamOperatorTestHarness<
+                        CommittableMessage<FileSinkCommittable>, CompactorRequest>
+                harness = new OneInputStreamOperatorTestHarness<>(coordinator)) {
+            harness.setup();
+            harness.open();
+
+            FileSinkCommittable committable0 = committable("0", "0", 5);
+            FileSinkCommittable committable1 = committable("0", "1", 6);
+            FileSinkCommittable committable2 = committable("0", "2", 5);
+            FileSinkCommittable committable3 = committable("1", "0", 5);
+
+            harness.processElement(message(committable0));
+            harness.processElement(message(committable1));
+
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+
+            harness.prepareSnapshotPreBarrier(1);
+            harness.snapshot(1, 1);
+
+            Assert.assertEquals(1, harness.extractOutputValues().size());
+
+            harness.processElement(message(committable2));
+            harness.processElement(message(committable3));
+
+            Assert.assertEquals(1, harness.extractOutputValues().size());
+
+            harness.prepareSnapshotPreBarrier(2);
+            harness.snapshot(2, 2);
+
+            List<CompactorRequest> results = harness.extractOutputValues();
+            Assert.assertEquals(3, results.size());
+            assertToCompact(results.get(0), committable0, committable1);
+            assertToCompact(results.get(1), committable2);
+            assertToCompact(results.get(2), committable3);
+        }
+    }
+
+    @Test
+    public void testCompactOnEndOfInput() throws Exception {
+        FileCompactStrategy strategy = Builder.newBuilder().withSizeThreshold(10).build();
+        CompactCoordinator coordinator =
+                new CompactCoordinator(strategy, getTestCommittableSerializer());
+
+        try (OneInputStreamOperatorTestHarness<
+                        CommittableMessage<FileSinkCommittable>, CompactorRequest>
+                harness = new OneInputStreamOperatorTestHarness<>(coordinator)) {
+            harness.setup();
+            harness.open();
+
+            FileSinkCommittable committable0 = committable("0", "0", 5);
+
+            harness.processElement(message(committable0));
+
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+
+            harness.prepareSnapshotPreBarrier(1);
+            harness.snapshot(1, 1);
+
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+
+            harness.endInput();
+
+            List<CompactorRequest> results = harness.extractOutputValues();
+            Assert.assertEquals(1, results.size());
+            assertToCompact(results.get(0), committable0);
+        }
+    }
+
+    @Test
+    public void testPassthrough() throws Exception {
+        FileCompactStrategy strategy = Builder.newBuilder().withSizeThreshold(10).build();
+        CompactCoordinator coordinator =
+                new CompactCoordinator(strategy, getTestCommittableSerializer());
+
+        try (OneInputStreamOperatorTestHarness<
+                        CommittableMessage<FileSinkCommittable>, CompactorRequest>
+                harness = new OneInputStreamOperatorTestHarness<>(coordinator)) {
+            harness.setup();
+            harness.open();
+
+            FileSinkCommittable cleanupToPassthrough = cleanupInprogress("0", "0", 1);
+            FileSinkCommittable sizeUnavailableToPassthrough = committable("0", "1", -1);
+            FileSinkCommittable normalCommittable = committable("0", "2", 10);
+
+            harness.processElement(message(cleanupToPassthrough));
+            harness.processElement(message(sizeUnavailableToPassthrough));
+            harness.processElement(message(normalCommittable));
+
+            List<CompactorRequest> results = harness.extractOutputValues();
+            Assert.assertEquals(1, results.size());
+            assertToCompact(results.get(0), normalCommittable);
+            assertToPassthrough(results.get(0), cleanupToPassthrough, sizeUnavailableToPassthrough);
+        }
+    }
+
+    @Test
+    public void testRestore() throws Exception {
+        FileCompactStrategy strategy = Builder.newBuilder().withSizeThreshold(10).build();
+        CompactCoordinator coordinator =
+                new CompactCoordinator(strategy, getTestCommittableSerializer());
+
+        FileSinkCommittable committable0 = committable("0", "0", 5);
+        FileSinkCommittable committable1 = committable("0", "1", 6);
+        FileSinkCommittable committable2 = committable("0", "2", 5);
+        FileSinkCommittable committable3 = committable("1", "0", 5);
+
+        OperatorSubtaskState state;
+        try (OneInputStreamOperatorTestHarness<
+                        CommittableMessage<FileSinkCommittable>, CompactorRequest>
+                harness = new OneInputStreamOperatorTestHarness<>(coordinator)) {
+            harness.setup();
+            harness.open();
+
+            harness.processElement(message(committable0));
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+
+            harness.prepareSnapshotPreBarrier(1);
+            state = harness.snapshot(1, 1);
+        }
+
+        coordinator = new CompactCoordinator(strategy, getTestCommittableSerializer());
+        try (OneInputStreamOperatorTestHarness<
+                        CommittableMessage<FileSinkCommittable>, CompactorRequest>
+                harness = new OneInputStreamOperatorTestHarness<>(coordinator)) {
+            harness.setup();
+            harness.initializeState(state);
+            harness.open();
+
+            harness.processElement(message(committable1));
+
+            Assert.assertEquals(1, harness.extractOutputValues().size());
+
+            harness.processElement(message(committable2));
+            harness.processElement(message(committable3));
+
+            Assert.assertEquals(1, harness.extractOutputValues().size());
+
+            harness.endInput();
+
+            List<CompactorRequest> results = harness.extractOutputValues();
+            Assert.assertEquals(3, results.size());
+            assertToCompact(results.get(0), committable0, committable1);
+            assertToCompact(results.get(1), committable2);
+            assertToCompact(results.get(2), committable3);
+        }
+    }
+
+    @Test
+    public void testRestoreWithChangedStrategy() throws Exception {
+        FileCompactStrategy strategy = Builder.newBuilder().withSizeThreshold(100).build();
+        CompactCoordinator coordinator =
+                new CompactCoordinator(strategy, getTestCommittableSerializer());
+
+        FileSinkCommittable committable0 = committable("0", "0", 5);
+        FileSinkCommittable committable1 = committable("0", "1", 6);
+        FileSinkCommittable committable2 = committable("0", "2", 7);
+        FileSinkCommittable committable3 = committable("0", "3", 8);
+        FileSinkCommittable committable4 = committable("0", "4", 9);
+        FileSinkCommittable committable5 = committable("0", "5", 2);
+
+        OperatorSubtaskState state;
+        try (OneInputStreamOperatorTestHarness<
+                        CommittableMessage<FileSinkCommittable>, CompactorRequest>
+                harness = new OneInputStreamOperatorTestHarness<>(coordinator)) {
+            harness.setup();
+            harness.open();
+
+            harness.processElement(message(committable0));
+            harness.processElement(message(committable1));
+            harness.processElement(message(committable2));
+            harness.processElement(message(committable3));
+            harness.processElement(message(committable4));
+
+            harness.prepareSnapshotPreBarrier(1);
+            state = harness.snapshot(1, 1);
+
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+        }
+
+        FileCompactStrategy changedStrategy = Builder.newBuilder().withSizeThreshold(10).build();
+        CompactCoordinator changedCoordinator =
+                new CompactCoordinator(changedStrategy, getTestCommittableSerializer());
+        try (OneInputStreamOperatorTestHarness<
+                        CommittableMessage<FileSinkCommittable>, CompactorRequest>
+                harness = new OneInputStreamOperatorTestHarness<>(changedCoordinator)) {
+            harness.setup();
+            harness.initializeState(state);
+            harness.open();
+
+            Assert.assertEquals(2, harness.extractOutputValues().size());
+
+            harness.processElement(message(committable5));
+
+            List<CompactorRequest> results = harness.extractOutputValues();
+            Assert.assertEquals(3, results.size());
+            assertToCompact(results.get(0), committable0, committable1);
+            assertToCompact(results.get(1), committable2, committable3);
+            assertToCompact(results.get(2), committable4, committable5);
+        }
+    }
+
+    private StreamRecord<CommittableMessage<FileSinkCommittable>> message(
+            FileSinkCommittable committable) {
+        return new StreamRecord<>(new CommittableWithLineage<>(committable, 1L, 0), 0L);
+    }
+
+    private FileSinkCommittable committable(String bucketId, String name, int size)
+            throws IOException {
+        // put bucketId after name to keep the possible '.' prefix in name
+        return new FileSinkCommittable(
+                bucketId,
+                new TestPendingFileRecoverable(
+                        newFile(name + "_" + bucketId, size <= 0 ? 1 : size), size));
+    }
+
+    private FileSinkCommittable cleanupInprogress(String bucketId, String name, int size)
+            throws IOException {
+        Path toCleanup = newFile(name + "_" + bucketId, size);
+        return new FileSinkCommittable(
+                bucketId, new TestInProgressFileRecoverable(toCleanup, size));
+    }
+
+    private SimpleVersionedSerializer<FileSinkCommittable> getTestCommittableSerializer() {
+        return new FileSinkCommittableSerializer(
+                new FileSinkTestUtils.SimpleVersionedWrapperSerializer<>(
+                        FileSinkTestUtils.TestPendingFileRecoverable::new),
+                new FileSinkTestUtils.SimpleVersionedWrapperSerializer<>(
+                        FileSinkTestUtils.TestInProgressFileRecoverable::new));
+    }
+
+    private void assertToCompact(CompactorRequest request, FileSinkCommittable... committables) {
+        List<FileSinkCommittable> committableToCompact = request.getCommittableToCompact();
+        Assert.assertArrayEquals(committables, committableToCompact.toArray());
+    }
+
+    private void assertToPassthrough(
+            CompactorRequest request, FileSinkCommittable... committables) {
+        List<FileSinkCommittable> committableToCompact = request.getCommittableToPassthrough();
+        Assert.assertArrayEquals(committables, committableToCompact.toArray());
+    }
+}

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactorOperatorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/compactor/CompactorOperatorTest.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.sink.compactor;
+
+import org.apache.flink.connector.file.sink.FileSinkCommittable;
+import org.apache.flink.connector.file.sink.FileSinkCommittableSerializer;
+import org.apache.flink.connector.file.sink.compactor.DecoderBasedReader.Decoder;
+import org.apache.flink.connector.file.sink.compactor.operator.CompactorOperator;
+import org.apache.flink.connector.file.sink.compactor.operator.CompactorRequest;
+import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils;
+import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils.TestInProgressFileRecoverable;
+import org.apache.flink.connector.file.sink.utils.FileSinkTestUtils.TestPendingFileRecoverable;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
+import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
+import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
+import org.apache.flink.streaming.api.functions.sink.filesystem.BucketWriter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter;
+import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter.InProgressFileRecoverable;
+import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter.PendingFileRecoverable;
+import org.apache.flink.streaming.api.functions.sink.filesystem.WriterProperties;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/** Test for {@link CompactorOperator}. */
+public class CompactorOperatorTest extends AbstractCompactTestBase {
+
+    @Test
+    public void testCompact() throws Exception {
+        FileCompactor fileCompactor =
+                new RecordWiseFileCompactor<>(
+                        new DecoderBasedReader.Factory<>((Decoder<Integer>) InputStream::read));
+        CompactorOperator compactor = createTestOperator(fileCompactor);
+
+        try (OneInputStreamOperatorTestHarness<
+                        CompactorRequest, CommittableMessage<FileSinkCommittable>>
+                harness = new OneInputStreamOperatorTestHarness<>(compactor)) {
+            harness.setup();
+            harness.open();
+
+            harness.processElement(
+                    request(
+                            "0",
+                            Arrays.asList(committable("0", ".0", 5), committable("0", ".1", 5)),
+                            null));
+
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+
+            harness.prepareSnapshotPreBarrier(1);
+            harness.snapshot(1, 1L);
+            harness.notifyOfCompletedCheckpoint(1);
+
+            compactor.getAllTasksFuture().join();
+
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+
+            harness.prepareSnapshotPreBarrier(2);
+
+            // 1summary+1compacted+2cleanup
+            List<CommittableMessage<FileSinkCommittable>> results = harness.extractOutputValues();
+            Assert.assertEquals(4, results.size());
+            SinkV2Assertions.assertThat((CommittableSummary<?>) results.get(0))
+                    .hasPendingCommittables(3);
+            SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(1))
+                    .hasCommittable(committable("0", "compacted-0", 10));
+            SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(2))
+                    .hasCommittable(cleanupPath("0", ".0"));
+            SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(3))
+                    .hasCommittable(cleanupPath("0", ".1"));
+        }
+    }
+
+    @Test
+    public void testPassthrough() throws Exception {
+        FileCompactor fileCompactor =
+                new RecordWiseFileCompactor<>(
+                        new DecoderBasedReader.Factory<>((Decoder<Integer>) InputStream::read));
+        CompactorOperator compactor = createTestOperator(fileCompactor);
+
+        try (OneInputStreamOperatorTestHarness<
+                        CompactorRequest, CommittableMessage<FileSinkCommittable>>
+                harness = new OneInputStreamOperatorTestHarness<>(compactor)) {
+            harness.setup();
+            harness.open();
+
+            FileSinkCommittable passThroughCommittable = committable("0", "0", 5);
+            FileSinkCommittable cleanupInprogressRequest = cleanupInprogress("0", "1", 1);
+            FileSinkCommittable cleanupPathRequest = cleanupPath("0", "2");
+
+            harness.processElement(
+                    request("0", Collections.singletonList(passThroughCommittable), null));
+            harness.processElement(
+                    request("0", null, Collections.singletonList(cleanupInprogressRequest)));
+            harness.processElement(
+                    request("0", null, Collections.singletonList(cleanupPathRequest)));
+
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+
+            harness.prepareSnapshotPreBarrier(1);
+            harness.snapshot(1, 1L);
+            harness.notifyOfCompletedCheckpoint(1);
+
+            compactor.getAllTasksFuture().join();
+
+            Assert.assertEquals(0, harness.extractOutputValues().size());
+
+            harness.prepareSnapshotPreBarrier(2);
+
+            List<CommittableMessage<FileSinkCommittable>> results = harness.extractOutputValues();
+            Assert.assertEquals(4, results.size());
+            SinkV2Assertions.assertThat((CommittableSummary<?>) results.get(0))
+                    .hasPendingCommittables(3);
+            SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(1))
+                    .hasCommittable(passThroughCommittable);
+            SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(2))
+                    .hasCommittable(cleanupInprogressRequest);
+            SinkV2Assertions.assertThat((CommittableWithLineage<?>) results.get(3))
+                    .hasCommittable(cleanupPathRequest);
+        }
+    }
+
+    private StreamRecord<CompactorRequest> request(
+            String bucketId,
+            List<FileSinkCommittable> toCompact,
+            List<FileSinkCommittable> toPassthrough) {
+        return new StreamRecord<>(
+                new CompactorRequest(
+                        bucketId,
+                        toCompact == null ? new ArrayList<>() : toCompact,
+                        toPassthrough == null ? new ArrayList<>() : toPassthrough),
+                0L);
+    }
+
+    private FileSinkCommittable committable(String bucketId, String name, int size)
+            throws IOException {
+        // put bucketId after name to keep the possible '.' prefix in name
+        return new FileSinkCommittable(
+                bucketId,
+                new TestPendingFileRecoverable(
+                        newFile(name + "_" + bucketId, size <= 0 ? 1 : size), size));
+    }
+
+    private FileSinkCommittable cleanupInprogress(String bucketId, String name, int size)
+            throws IOException {
+        Path toCleanup = newFile(name + "_" + bucketId, size);
+        return new FileSinkCommittable(
+                bucketId, new TestInProgressFileRecoverable(toCleanup, size));
+    }
+
+    private FileSinkCommittable cleanupPath(String bucketId, String name) throws IOException {
+        Path toCleanup = newFile(name + "_" + bucketId, 1);
+        return new FileSinkCommittable(bucketId, toCleanup);
+    }
+
+    private SimpleVersionedSerializer<FileSinkCommittable> getTestCommittableSerializer() {
+        return new FileSinkCommittableSerializer(
+                new FileSinkTestUtils.SimpleVersionedWrapperSerializer<>(
+                        TestPendingFileRecoverable::new),
+                new FileSinkTestUtils.SimpleVersionedWrapperSerializer<>(
+                        TestInProgressFileRecoverable::new));
+    }
+
+    private CompactorOperator createTestOperator(FileCompactor compactor) {
+        return new CompactorOperator(
+                2,
+                getTestCommittableSerializer(),
+                compactor,
+                new BucketWriter<Integer, String>() {
+
+                    @Override
+                    public InProgressFileWriter<Integer, String> openNewInProgressFile(
+                            String bucketId, Path path, long creationTime) throws IOException {
+                        return new InProgressFileWriter<Integer, String>() {
+                            BufferedWriter writer;
+                            long size = 0L;
+
+                            @Override
+                            public void write(Integer element, long currentTime)
+                                    throws IOException {
+                                if (writer == null) {
+                                    writer = new BufferedWriter(new FileWriter(path.toString()));
+                                }
+                                writer.write(element);
+                                size += 1;
+                            }
+
+                            @Override
+                            public InProgressFileRecoverable persist() throws IOException {
+                                return new TestInProgressFileRecoverable(path, size);
+                            }
+
+                            @Override
+                            public PendingFileRecoverable closeForCommit() throws IOException {
+                                return new TestPendingFileRecoverable(path, size);
+                            }
+
+                            @Override
+                            public void dispose() {}
+
+                            @Override
+                            public String getBucketId() {
+                                return bucketId;
+                            }
+
+                            @Override
+                            public long getCreationTime() {
+                                return 0;
+                            }
+
+                            @Override
+                            public long getSize() throws IOException {
+                                return size;
+                            }
+
+                            @Override
+                            public long getLastUpdateTime() {
+                                return 0;
+                            }
+                        };
+                    }
+
+                    @Override
+                    public InProgressFileWriter<Integer, String> resumeInProgressFileFrom(
+                            String s,
+                            InProgressFileRecoverable inProgressFileSnapshot,
+                            long creationTime)
+                            throws IOException {
+                        return null;
+                    }
+
+                    @Override
+                    public WriterProperties getProperties() {
+                        return null;
+                    }
+
+                    @Override
+                    public PendingFile recoverPendingFile(
+                            PendingFileRecoverable pendingFileRecoverable) throws IOException {
+                        return new PendingFile() {
+                            @Override
+                            public void commit() throws IOException {
+                                TestPendingFileRecoverable testRecoverable =
+                                        (TestPendingFileRecoverable) pendingFileRecoverable;
+                                if (testRecoverable.getPath() != null) {
+                                    if (!testRecoverable
+                                            .getPath()
+                                            .equals(testRecoverable.getUncommittedPath())) {
+                                        testRecoverable
+                                                .getPath()
+                                                .getFileSystem()
+                                                .rename(
+                                                        testRecoverable.getUncommittedPath(),
+                                                        testRecoverable.getPath());
+                                    }
+                                }
+                            }
+
+                            @Override
+                            public void commitAfterRecovery() throws IOException {
+                                commit();
+                            }
+                        };
+                    }
+
+                    @Override
+                    public boolean cleanupInProgressFileRecoverable(
+                            InProgressFileRecoverable inProgressFileRecoverable)
+                            throws IOException {
+                        return false;
+                    }
+                });
+    }
+}

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/utils/FileSinkTestUtils.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/utils/FileSinkTestUtils.java
@@ -36,31 +36,105 @@ public class FileSinkTestUtils {
     /** A type of testing {@link InProgressFileWriter.PendingFileRecoverable}. */
     public static class TestPendingFileRecoverable extends StringValue
             implements InProgressFileWriter.PendingFileRecoverable {
+        private Path path;
+        private Path uncommittedPath;
+        private long size;
+
+        public TestPendingFileRecoverable() {
+            this.path = null;
+            this.uncommittedPath = null;
+            this.size = -1L;
+        }
+
+        public TestPendingFileRecoverable(Path path, long size) {
+            this.path = path;
+            this.uncommittedPath = new Path(path.getParent(), "." + path.getName());
+            this.size = size;
+        }
+
+        public TestPendingFileRecoverable(Path path, Path uncommittedPath, long size) {
+            this.path = path;
+            this.uncommittedPath = uncommittedPath;
+            this.size = size;
+        }
+
         @Override
         public Path getPath() {
-            return null;
+            return path;
+        }
+
+        public Path getUncommittedPath() {
+            return uncommittedPath;
         }
 
         @Override
         public long getSize() {
-            return -1L;
+            return size;
         }
-        // Nope
+
+        @Override
+        public String getValue() {
+            return size + "," + path.toUri().toString();
+        }
+
+        @Override
+        public void setValue(CharSequence value, int offset, int len) {
+            String[] arr = value.subSequence(offset, len).toString().split(",");
+            size = Integer.parseInt(arr[0]);
+            path = new Path(arr[1]);
+        }
     }
 
     /** A type of testing {@link InProgressFileWriter.InProgressFileRecoverable}. */
     public static class TestInProgressFileRecoverable extends StringValue
             implements InProgressFileWriter.InProgressFileRecoverable {
+        private Path path;
+        private Path uncommittedPath;
+        private long size;
+
+        public TestInProgressFileRecoverable() {
+            this.path = null;
+            this.uncommittedPath = null;
+            this.size = -1L;
+        }
+
+        public TestInProgressFileRecoverable(Path path, long size) {
+            this.path = path;
+            this.uncommittedPath = new Path(path.getParent(), "." + path.getName());
+            this.size = size;
+        }
+
+        public TestInProgressFileRecoverable(Path path, Path uncommittedPath, long size) {
+            this.path = path;
+            this.uncommittedPath = uncommittedPath;
+            this.size = size;
+        }
+
         @Override
         public Path getPath() {
-            return null;
+            return path;
+        }
+
+        public Path getUncommittedPath() {
+            return uncommittedPath;
         }
 
         @Override
         public long getSize() {
-            return -1L;
+            return size;
         }
-        // Nope
+
+        @Override
+        public String getValue() {
+            return size + "," + path.toUri().toString();
+        }
+
+        @Override
+        public void setValue(CharSequence value, int offset, int len) {
+            String[] arr = value.subSequence(offset, len).toString().split(",");
+            size = Integer.parseInt(arr[0]);
+            path = new Path(arr[1]);
+        }
     }
 
     /**

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/utils/FileSinkTestUtils.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/utils/FileSinkTestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.file.sink.utils;
 
 import org.apache.flink.connector.file.sink.FileSink;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.streaming.api.functions.sink.filesystem.BucketAssigner;
 import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter;
@@ -35,12 +36,30 @@ public class FileSinkTestUtils {
     /** A type of testing {@link InProgressFileWriter.PendingFileRecoverable}. */
     public static class TestPendingFileRecoverable extends StringValue
             implements InProgressFileWriter.PendingFileRecoverable {
+        @Override
+        public Path getPath() {
+            return null;
+        }
+
+        @Override
+        public long getSize() {
+            return -1L;
+        }
         // Nope
     }
 
     /** A type of testing {@link InProgressFileWriter.InProgressFileRecoverable}. */
     public static class TestInProgressFileRecoverable extends StringValue
             implements InProgressFileWriter.InProgressFileRecoverable {
+        @Override
+        public Path getPath() {
+            return null;
+        }
+
+        @Override
+        public long getSize() {
+            return -1L;
+        }
         // Nope
     }
 

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BucketWriter.java
@@ -40,6 +40,32 @@ public interface BucketWriter<IN, BucketID> {
             final BucketID bucketID, final Path path, final long creationTime) throws IOException;
 
     /**
+     * Used to create a new {@link CompactingFileWriter} of the requesting type. A {@link
+     * InProgressFileWriter} will be created by default, which supports only the RECORD_WISE type.
+     * Requesting a writer of an unsupported type will result in an UnsupportedOperationException.
+     *
+     * @param type the type of this writer.
+     * @param bucketID the id of the bucket this writer is writing to.
+     * @param path the path this writer will write to.
+     * @param creationTime the creation time of the file.
+     * @return the new {@link InProgressFileWriter}
+     * @throws IOException Thrown if creating a writer fails.
+     * @throws UnsupportedOperationException Thrown if the bucket writer doesn't support the
+     *     requesting type.
+     */
+    default CompactingFileWriter openNewCompactingFile(
+            final CompactingFileWriter.Type type,
+            final BucketID bucketID,
+            final Path path,
+            final long creationTime)
+            throws IOException {
+        if (type == CompactingFileWriter.Type.RECORD_WISE) {
+            return openNewInProgressFile(bucketID, path, creationTime);
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Used to resume a {@link InProgressFileWriter} from a {@link
      * InProgressFileWriter.InProgressFileRecoverable}.
      *

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkBucketWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkBucketWriter.java
@@ -50,6 +50,7 @@ public class BulkBucketWriter<IN, BucketID>
     public InProgressFileWriter<IN, BucketID> resumeFrom(
             final BucketID bucketId,
             final RecoverableFsDataOutputStream stream,
+            final Path path,
             final RecoverableWriter.ResumeRecoverable resumable,
             final long creationTime)
             throws IOException {
@@ -58,7 +59,7 @@ public class BulkBucketWriter<IN, BucketID>
         Preconditions.checkNotNull(resumable);
 
         final BulkWriter<IN> writer = writerFactory.create(stream);
-        return new BulkPartWriter<>(bucketId, stream, writer, creationTime);
+        return new BulkPartWriter<>(bucketId, path, stream, writer, creationTime);
     }
 
     @Override
@@ -73,6 +74,6 @@ public class BulkBucketWriter<IN, BucketID>
         Preconditions.checkNotNull(path);
 
         final BulkWriter<IN> writer = writerFactory.create(stream);
-        return new BulkPartWriter<>(bucketId, stream, writer, creationTime);
+        return new BulkPartWriter<>(bucketId, path, stream, writer, creationTime);
     }
 }

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkPartWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/BulkPartWriter.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.BulkWriter;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.util.Preconditions;
 
@@ -36,10 +37,11 @@ final class BulkPartWriter<IN, BucketID> extends OutputStreamBasedPartFileWriter
 
     BulkPartWriter(
             final BucketID bucketId,
+            final Path path,
             final RecoverableFsDataOutputStream currentPartStream,
             final BulkWriter<IN> writer,
             final long creationTime) {
-        super(bucketId, currentPartStream, creationTime);
+        super(bucketId, path, currentPartStream, creationTime);
         this.writer = Preconditions.checkNotNull(writer);
     }
 

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/CompactingFileWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/CompactingFileWriter.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem;
+
+import org.apache.flink.streaming.api.functions.sink.filesystem.InProgressFileWriter.PendingFileRecoverable;
+
+import java.io.IOException;
+
+/**
+ * The file sink compactors use the {@link CompactingFileWriter} to write a compacting file.
+ *
+ * <p>A class should not directly implement the {@link CompactingFileWriter}, but to implement the
+ * {@link RecordWiseCompactingFileWriter}, or the {@link OutputStreamBasedCompactingFileWriter}, or
+ * both. If an class implements both interfaces, once the write method of either interface is
+ * called, the write method in the other one should be disabled.
+ */
+public interface CompactingFileWriter {
+
+    /**
+     * Closes the writer and gets the {@link PendingFileRecoverable} of the written compacting file.
+     *
+     * @return The state of the pending part file. {@link Bucket} uses this to commit the pending
+     *     file.
+     * @throws IOException Thrown if an I/O error occurs.
+     */
+    PendingFileRecoverable closeForCommit() throws IOException;
+
+    /** Enum defining the types of {@link CompactingFileWriter}. */
+    enum Type {
+        RECORD_WISE,
+        OUTPUT_STREAM
+    }
+}

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/InProgressFileWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/InProgressFileWriter.java
@@ -19,6 +19,9 @@
 package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.Path;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 
@@ -63,5 +66,13 @@ public interface InProgressFileWriter<IN, BucketID>
     interface InProgressFileRecoverable extends PendingFileRecoverable {}
 
     /** The handle can be used to recover pending file. */
-    interface PendingFileRecoverable {}
+    interface PendingFileRecoverable {
+
+        /** @return The target path of the pending file, null if unavailable. */
+        @Nullable
+        Path getPath();
+
+        /** @return The size of the pending file, -1 if unavailable. */
+        long getSize();
+    }
 }

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/InProgressFileWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/InProgressFileWriter.java
@@ -24,7 +24,8 @@ import java.io.IOException;
 
 /** The {@link Bucket} uses the {@link InProgressFileWriter} to write element to a part file. */
 @Internal
-public interface InProgressFileWriter<IN, BucketID> extends PartFileInfo<BucketID> {
+public interface InProgressFileWriter<IN, BucketID>
+        extends PartFileInfo<BucketID>, RecordWiseCompactingFileWriter<IN> {
 
     /**
      * Write an element to the part file.
@@ -50,6 +51,11 @@ public interface InProgressFileWriter<IN, BucketID> extends PartFileInfo<BucketI
 
     /** Dispose the part file. */
     void dispose();
+
+    @Override
+    default void write(IN element) throws IOException {
+        write(element, System.currentTimeMillis());
+    }
 
     // ------------------------------------------------------------------------
 

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputStreamBasedCompactingFileWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputStreamBasedCompactingFileWriter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * The compactors use the {@link OutputStreamBasedCompactingFileWriter} to directly write a
+ * compacting file as an {@link OutputStream}.
+ */
+public interface OutputStreamBasedCompactingFileWriter extends CompactingFileWriter {
+    /**
+     * Get the output stream underlying the writer. The close method of the returned stream should
+     * never be called.
+     *
+     * @return The output stream to write the compacting file.
+     * @throws IOException Thrown if acquiring the stream fails.
+     */
+    OutputStream asOutputStream() throws IOException;
+}

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputStreamBasedPartFileWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/OutputStreamBasedPartFileWriter.java
@@ -42,24 +42,29 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
         extends AbstractPartFileWriter<IN, BucketID> {
 
     final RecoverableFsDataOutputStream currentPartStream;
+    final Path targetPath;
 
     OutputStreamBasedPartFileWriter(
             final BucketID bucketID,
+            final Path path,
             final RecoverableFsDataOutputStream recoverableFsDataOutputStream,
             final long createTime) {
         super(bucketID, createTime);
+        this.targetPath = path;
         this.currentPartStream = recoverableFsDataOutputStream;
     }
 
     @Override
     public InProgressFileRecoverable persist() throws IOException {
-        return new OutputStreamBasedInProgressFileRecoverable(currentPartStream.persist());
+        return new OutputStreamBasedInProgressFileRecoverable(
+                currentPartStream.persist(), targetPath);
     }
 
     @Override
     public PendingFileRecoverable closeForCommit() throws IOException {
+        long size = currentPartStream.getPos();
         return new OutputStreamBasedPendingFileRecoverable(
-                currentPartStream.closeForCommit().getRecoverable());
+                currentPartStream.closeForCommit().getRecoverable(), targetPath, size);
     }
 
     @Override
@@ -103,6 +108,7 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
                     bucketID,
                     recoverableWriter.recover(
                             outputStreamBasedInProgressRecoverable.getResumeRecoverable()),
+                    inProgressFileRecoverable.getPath(),
                     outputStreamBasedInProgressRecoverable.getResumeRecoverable(),
                     creationTime);
         }
@@ -158,6 +164,7 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
         public abstract InProgressFileWriter<IN, BucketID> resumeFrom(
                 final BucketID bucketId,
                 final RecoverableFsDataOutputStream stream,
+                final Path path,
                 final RecoverableWriter.ResumeRecoverable resumable,
                 final long creationTime)
                 throws IOException;
@@ -170,14 +177,37 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
             implements PendingFileRecoverable {
 
         private final RecoverableWriter.CommitRecoverable commitRecoverable;
+        private final Path targetPath;
+        private final long fileSize;
 
+        @Deprecated
+        // Remained for state compatibility
         public OutputStreamBasedPendingFileRecoverable(
                 final RecoverableWriter.CommitRecoverable commitRecoverable) {
+            this(commitRecoverable, null, -1L);
+        }
+
+        public OutputStreamBasedPendingFileRecoverable(
+                final RecoverableWriter.CommitRecoverable commitRecoverable,
+                final Path targetPath,
+                final long fileSize) {
             this.commitRecoverable = commitRecoverable;
+            this.targetPath = targetPath;
+            this.fileSize = fileSize;
         }
 
         RecoverableWriter.CommitRecoverable getCommitRecoverable() {
             return commitRecoverable;
+        }
+
+        @Override
+        public Path getPath() {
+            return targetPath;
+        }
+
+        @Override
+        public long getSize() {
+            return fileSize;
         }
     }
 
@@ -189,14 +219,35 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
             implements InProgressFileRecoverable {
 
         private final RecoverableWriter.ResumeRecoverable resumeRecoverable;
+        private final Path targetPath;
 
+        @Deprecated
+        // Remained for state compatibility
         public OutputStreamBasedInProgressFileRecoverable(
                 final RecoverableWriter.ResumeRecoverable resumeRecoverable) {
+            this(resumeRecoverable, null);
+        }
+
+        public OutputStreamBasedInProgressFileRecoverable(
+                final RecoverableWriter.ResumeRecoverable resumeRecoverable,
+                final Path targetPath) {
             this.resumeRecoverable = resumeRecoverable;
+            this.targetPath = targetPath;
         }
 
         RecoverableWriter.ResumeRecoverable getResumeRecoverable() {
             return resumeRecoverable;
+        }
+
+        @Override
+        public Path getPath() {
+            return targetPath;
+        }
+
+        @Override
+        public long getSize() {
+            // File size of an in progress file is unavailable.
+            return -1L;
         }
     }
 
@@ -235,7 +286,7 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
 
         @Override
         public int getVersion() {
-            return 1;
+            return 2;
         }
 
         @Override
@@ -245,7 +296,7 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
                     (OutputStreamBasedInProgressFileRecoverable) inProgressRecoverable;
             DataOutputSerializer dataOutputSerializer = new DataOutputSerializer(256);
             dataOutputSerializer.writeInt(MAGIC_NUMBER);
-            serializeV1(outputStreamBasedInProgressRecoverable, dataOutputSerializer);
+            serializeV2(outputStreamBasedInProgressRecoverable, dataOutputSerializer);
             return dataOutputSerializer.getCopyOfBuffer();
         }
 
@@ -257,6 +308,10 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
                     DataInputView dataInputView = new DataInputDeserializer(serialized);
                     validateMagicNumber(dataInputView);
                     return deserializeV1(dataInputView);
+                case 2:
+                    dataInputView = new DataInputDeserializer(serialized);
+                    validateMagicNumber(dataInputView);
+                    return deserializeV2(dataInputView);
                 default:
                     throw new IOException("Unrecognized version or corrupt state: " + version);
             }
@@ -267,11 +322,17 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
             return resumeSerializer;
         }
 
-        private void serializeV1(
+        private void serializeV2(
                 final OutputStreamBasedInProgressFileRecoverable
                         outputStreamBasedInProgressRecoverable,
                 final DataOutputView dataOutputView)
                 throws IOException {
+            boolean pathAvailable = outputStreamBasedInProgressRecoverable.targetPath != null;
+            dataOutputView.writeBoolean(pathAvailable);
+            if (pathAvailable) {
+                dataOutputView.writeUTF(
+                        outputStreamBasedInProgressRecoverable.targetPath.toUri().toString());
+            }
             SimpleVersionedSerialization.writeVersionAndSerialize(
                     resumeSerializer,
                     outputStreamBasedInProgressRecoverable.getResumeRecoverable(),
@@ -283,6 +344,18 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
             return new OutputStreamBasedInProgressFileRecoverable(
                     SimpleVersionedSerialization.readVersionAndDeSerialize(
                             resumeSerializer, dataInputView));
+        }
+
+        private OutputStreamBasedInProgressFileRecoverable deserializeV2(
+                final DataInputView dataInputView) throws IOException {
+            Path path = null;
+            if (dataInputView.readBoolean()) {
+                path = new Path(dataInputView.readUTF());
+            }
+            return new OutputStreamBasedInProgressFileRecoverable(
+                    SimpleVersionedSerialization.readVersionAndDeSerialize(
+                            resumeSerializer, dataInputView),
+                    path);
         }
 
         private static void validateMagicNumber(final DataInputView dataInputView)
@@ -312,7 +385,7 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
 
         @Override
         public int getVersion() {
-            return 1;
+            return 2;
         }
 
         @Override
@@ -321,7 +394,7 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
                     (OutputStreamBasedPendingFileRecoverable) pendingFileRecoverable;
             DataOutputSerializer dataOutputSerializer = new DataOutputSerializer(256);
             dataOutputSerializer.writeInt(MAGIC_NUMBER);
-            serializeV1(outputStreamBasedPendingFileRecoverable, dataOutputSerializer);
+            serializeV2(outputStreamBasedPendingFileRecoverable, dataOutputSerializer);
             return dataOutputSerializer.getCopyOfBuffer();
         }
 
@@ -333,7 +406,10 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
                     DataInputDeserializer in = new DataInputDeserializer(serialized);
                     validateMagicNumber(in);
                     return deserializeV1(in);
-
+                case 2:
+                    in = new DataInputDeserializer(serialized);
+                    validateMagicNumber(in);
+                    return deserializeV2(in);
                 default:
                     throw new IOException("Unrecognized version or corrupt state: " + version);
             }
@@ -344,11 +420,18 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
             return this.commitSerializer;
         }
 
-        private void serializeV1(
+        private void serializeV2(
                 final OutputStreamBasedPendingFileRecoverable
                         outputStreamBasedPendingFileRecoverable,
                 final DataOutputView dataOutputView)
                 throws IOException {
+            boolean pathAvailable = outputStreamBasedPendingFileRecoverable.targetPath != null;
+            dataOutputView.writeBoolean(pathAvailable);
+            if (pathAvailable) {
+                dataOutputView.writeUTF(
+                        outputStreamBasedPendingFileRecoverable.targetPath.toUri().toString());
+            }
+            dataOutputView.writeLong(outputStreamBasedPendingFileRecoverable.getSize());
             SimpleVersionedSerialization.writeVersionAndSerialize(
                     commitSerializer,
                     outputStreamBasedPendingFileRecoverable.getCommitRecoverable(),
@@ -360,6 +443,20 @@ public abstract class OutputStreamBasedPartFileWriter<IN, BucketID>
             return new OutputStreamBasedPendingFileRecoverable(
                     SimpleVersionedSerialization.readVersionAndDeSerialize(
                             commitSerializer, dataInputView));
+        }
+
+        private OutputStreamBasedPendingFileRecoverable deserializeV2(
+                final DataInputView dataInputView) throws IOException {
+            Path path = null;
+            if (dataInputView.readBoolean()) {
+                path = new Path(dataInputView.readUTF());
+            }
+            long size = dataInputView.readLong();
+            return new OutputStreamBasedPendingFileRecoverable(
+                    SimpleVersionedSerialization.readVersionAndDeSerialize(
+                            commitSerializer, dataInputView),
+                    path,
+                    size);
         }
 
         private static void validateMagicNumber(final DataInputView dataInputView)

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RecordWiseCompactingFileWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RecordWiseCompactingFileWriter.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.functions.sink.filesystem;
+
+import org.apache.flink.annotation.Internal;
+
+import java.io.IOException;
+
+/**
+ * The compactors use the {@link RecordWiseCompactingFileWriter} to write elements to a compacting
+ * file.
+ */
+@Internal
+public interface RecordWiseCompactingFileWriter<IN> extends CompactingFileWriter {
+    /**
+     * Write an element to the compacting file.
+     *
+     * @param element the element to be written.
+     * @throws IOException Thrown if writing the element fails.
+     */
+    void write(IN element) throws IOException;
+}

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWiseBucketWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWiseBucketWriter.java
@@ -25,6 +25,8 @@ import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.util.Preconditions;
 
+import java.io.IOException;
+
 /**
  * A factory that creates {@link RowWisePartWriter RowWisePartWriters}.
  *
@@ -67,5 +69,13 @@ public class RowWiseBucketWriter<IN, BucketID>
         Preconditions.checkNotNull(path);
 
         return new RowWisePartWriter<>(bucketId, stream, encoder, creationTime);
+    }
+
+    @Override
+    public CompactingFileWriter openNewCompactingFile(
+            CompactingFileWriter.Type type, BucketID bucketID, Path path, long creationTime)
+            throws IOException {
+        // Both types are supported, overwrite to avoid UnsupportedOperationException.
+        return openNewInProgressFile(bucketID, path, creationTime);
     }
 }

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWiseBucketWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWiseBucketWriter.java
@@ -49,13 +49,14 @@ public class RowWiseBucketWriter<IN, BucketID>
     public InProgressFileWriter<IN, BucketID> resumeFrom(
             final BucketID bucketId,
             final RecoverableFsDataOutputStream stream,
+            final Path path,
             final RecoverableWriter.ResumeRecoverable resumable,
             final long creationTime) {
 
         Preconditions.checkNotNull(stream);
         Preconditions.checkNotNull(resumable);
 
-        return new RowWisePartWriter<>(bucketId, stream, encoder, creationTime);
+        return new RowWisePartWriter<>(bucketId, path, stream, encoder, creationTime);
     }
 
     @Override
@@ -68,7 +69,7 @@ public class RowWiseBucketWriter<IN, BucketID>
         Preconditions.checkNotNull(stream);
         Preconditions.checkNotNull(path);
 
-        return new RowWisePartWriter<>(bucketId, stream, encoder, creationTime);
+        return new RowWisePartWriter<>(bucketId, path, stream, encoder, creationTime);
     }
 
     @Override

--- a/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWisePartWriter.java
+++ b/flink-connectors/flink-file-sink-common/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/RowWisePartWriter.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.api.functions.sink.filesystem;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.Encoder;
+import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.util.Preconditions;
 
@@ -41,10 +42,11 @@ public final class RowWisePartWriter<IN, BucketID>
 
     public RowWisePartWriter(
             final BucketID bucketId,
+            final Path path,
             final RecoverableFsDataOutputStream currentPartStream,
             final Encoder<IN> encoder,
             final long creationTime) {
-        super(bucketId, currentPartStream, creationTime);
+        super(bucketId, path, currentPartStream, creationTime);
         this.encoder = Preconditions.checkNotNull(encoder);
     }
 

--- a/flink-core/src/main/java/org/apache/flink/util/function/SerializableSupplierWithException.java
+++ b/flink-core/src/main/java/org/apache/flink/util/function/SerializableSupplierWithException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.function;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+
+/**
+ * A serializable {@link SupplierWithException}.
+ *
+ * @param <T> the type of results supplied by this supplier.
+ * @param <E> The type of Exceptions thrown by this function.
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface SerializableSupplierWithException<T, E extends Exception>
+        extends SupplierWithException<T, E>, Serializable {}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
